### PR TITLE
Fix JavaScript errors and add missing section

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rafael Paulino - Currículo Online</title>
     <link rel="stylesheet" href="style.css" />
-    <script src="script.js"></script>
   </head>
   <body>
     <nav>
@@ -99,6 +98,11 @@
           mas conhecimento também, eu busco minha realização pessoal.
         </li>
       </ul>
+    </section>
+
+    <section id="projetos" class="card">
+      <h2><i class="fas fa-tasks"></i> Projetos</h2>
+      <!-- Adicionar projetos aqui -->
     </section>
 
     <section id="contato" class="card">


### PR DESCRIPTION
This commit addresses two issues that were likely causing runtime errors:

1.  Removed a duplicate `<script>` tag from the `<head>` in `index.html`. Loading scripts in the head can cause errors when the script tries to access DOM elements that have not yet been parsed.

2.  Added the missing `<section id="projetos">`. The navigation menu contained a link to `#projetos`, but the element did not exist. This would cause a `TypeError` when the link was clicked, as the JavaScript would attempt to call `scrollIntoView` on a `null` element.